### PR TITLE
Mtw 102 - Loading Screen

### DIFF
--- a/frontend/components/outcomes/OutcomesScreen.js
+++ b/frontend/components/outcomes/OutcomesScreen.js
@@ -1,6 +1,6 @@
 import Constants from 'expo-constants';
 import React, { useEffect, useState } from 'react';
-import { FlatList, LogBox, SafeAreaView, StyleSheet, Text } from 'react-native';
+import { ActivityIndicator, FlatList, LogBox, SafeAreaView, StyleSheet, Text } from 'react-native';
 import { getAccessToken } from '../../utils/auth.js';
 import Outcome from './Outcome';
 
@@ -24,6 +24,7 @@ const styles = StyleSheet.create({
 export default function OutcomesScreen({ navigation, route }) {
 
     const [dataTemp, setDataTemp] = useState([]);
+    const [dataLoaded, setDataLoaded] = useState(false);
 
     useEffect(() => {
 
@@ -100,6 +101,8 @@ export default function OutcomesScreen({ navigation, route }) {
 
                     // Update the dataTemp variable with the newly parsed data
                     setDataTemp(newData);
+                    // Update the dataLoaded variable so OutcomeScreen replaces loading circle
+                    setDataLoaded(true);
                 })
                 .catch((error) => {
                     console.error(error);
@@ -111,25 +114,32 @@ export default function OutcomesScreen({ navigation, route }) {
     }, []);
 
     return (
-        <SafeAreaView style={styles.container}>
-            {dataTemp ?
-                <FlatList 
-                    style={styles.listStyle}
-                    data={dataTemp}
-                    renderItem={({ item }) => {
-                        return (
-                            <Outcome data={[item]}/>
-                        );
-                    }}
-                    keyExtractor={item => item.title}
-                />
-            :
-                <SafeAreaView style={styles.error_parent}>
-                    <Text style={styles.error_message}> 
-                        There are no outcomes to display.{"\n"}Please contact your manager or More Than Words{"\n"}administrator if you think this is an error.
-                    </Text>
-                </SafeAreaView>
-            }
-        </SafeAreaView>
+        dataLoaded ?
+            //If data has loaded, then render the OutcomeScreen normally
+            <SafeAreaView style={styles.container}>
+                {dataTemp ?
+                    <FlatList 
+                        style={styles.listStyle}
+                        data={dataTemp}
+                        renderItem={({ item }) => {
+                            return (
+                                <Outcome data={[item]}/>
+                            );
+                        }}
+                        keyExtractor={item => item.title}
+                    />
+                :
+                    <SafeAreaView style={styles.error_parent}>
+                        <Text style={styles.error_message}> 
+                            There are no outcomes to display.{"\n"}Please contact your manager or More Than Words{"\n"}administrator if you think this is an error.
+                        </Text>
+                    </SafeAreaView>
+                }
+            </SafeAreaView>
+        : 
+            //If data hasn't loaded, then display loading circle
+            <SafeAreaView style={{flex: 1, justifyContent: 'center'}}>
+                <ActivityIndicator size="large" />
+            </SafeAreaView>
     );
 }

--- a/frontend/components/pod_components/PodScreen.js
+++ b/frontend/components/pod_components/PodScreen.js
@@ -54,35 +54,33 @@ export default class PodScreen extends React.Component {
     render() {
         let IDkey = 0;
         const dict = this.state.outcomes_list;
-        //If data has loaded, then render the FocusAreaBlock
-        if (this.state.data_loaded) {
             return (
-                <ScrollView>
-                    <SafeAreaView style={styles.container}>
-                        {Object.entries(dict).map(([key, value]) => {
-                            IDkey++;
-                            return (
-                                <FocusAreaBlock 
-                                    pod={key}
-                                    name={dict[key]['name']}
-                                    completed_outcomes={dict[key]['completed_outcomes']}
-                                    total_outcomes={dict[key]['total_outcomes']}
-                                    key={IDkey}
-                                    route={this.props.route}
-                                    navigation={this.props.navigation}
-                                />
-                            )
-                        })}
+                this.state.data_loaded ?
+                    //If data has loaded, then render the FocusAreaBlock
+                    <ScrollView>
+                        <SafeAreaView style={styles.container}>
+                            {Object.entries(dict).map(([key, value]) => {
+                                IDkey++;
+                                return (
+                                    <FocusAreaBlock 
+                                        pod={key}
+                                        name={dict[key]['name']}
+                                        completed_outcomes={dict[key]['completed_outcomes']}
+                                        total_outcomes={dict[key]['total_outcomes']}
+                                        key={IDkey}
+                                        route={this.props.route}
+                                        navigation={this.props.navigation}
+                                    />
+                                )
+                            })}
+                        </SafeAreaView>
+                    </ScrollView>
+                :
+                    //If data hasn't loaded, display loading circle
+                    <SafeAreaView style={{flex: 1, justifyContent: 'center'}}>
+                        <ActivityIndicator size="large" />
                     </SafeAreaView>
-                </ScrollView>
             ); 
-        }
-        //If data hasn't loaded, display loading circle
-        return (
-            <SafeAreaView style={{flex: 1, justifyContent: 'center'}}>
-                <ActivityIndicator size="large" />
-            </SafeAreaView>
-        );
     }
 }
 

--- a/frontend/components/pod_components/PodScreen.js
+++ b/frontend/components/pod_components/PodScreen.js
@@ -56,11 +56,7 @@ export default class PodScreen extends React.Component {
         const dict = this.state.outcomes_list;
             return (
                 this.state.data_loaded ?
-<<<<<<< HEAD
                     // If data has loaded, then render the FocusAreaBlock
-=======
-                    //If data has loaded, then render the FocusAreaBlock
->>>>>>> 098826967770cb595937538a6dd8cf3dc52b7e03
                     <ScrollView>
                         <SafeAreaView style={styles.container}>
                             {Object.entries(dict).map(([key, value]) => {
@@ -80,11 +76,7 @@ export default class PodScreen extends React.Component {
                         </SafeAreaView>
                     </ScrollView>
                 :
-<<<<<<< HEAD
                     // If data hasn't loaded, then display loading circle
-=======
-                    //If data hasn't loaded, display loading circle
->>>>>>> 098826967770cb595937538a6dd8cf3dc52b7e03
                     <SafeAreaView style={{flex: 1, justifyContent: 'center'}}>
                         <ActivityIndicator size="large" />
                     </SafeAreaView>

--- a/frontend/components/pod_components/PodScreen.js
+++ b/frontend/components/pod_components/PodScreen.js
@@ -54,35 +54,33 @@ export default class PodScreen extends React.Component {
     render() {
         let IDkey = 0;
         const dict = this.state.outcomes_list;
-        //If data has loaded, then render the FocusAreaBlock
-        if (this.state.data_loaded) {
             return (
-                <ScrollView>
-                    <SafeAreaView style={styles.container}>
-                        {Object.entries(dict).map(([key, value]) => {
-                            IDkey++;
-                            return (
-                                <FocusAreaBlock 
-                                    pod={key}
-                                    name={dict[key]['name']}
-                                    completed_outcomes={dict[key]['completed_outcomes']}
-                                    total_outcomes={dict[key]['total_outcomes']}
-                                    key={IDkey}
-                                    route={this.props.route}
-                                    navigation={this.props.navigation}
-                                />
-                            )
-                        })}
+                this.state.data_loaded ?
+                    // If data has loaded, then render the FocusAreaBlock
+                    <ScrollView>
+                        <SafeAreaView style={styles.container}>
+                            {Object.entries(dict).map(([key, value]) => {
+                                IDkey++;
+                                return (
+                                    <FocusAreaBlock 
+                                        pod={key}
+                                        name={dict[key]['name']}
+                                        completed_outcomes={dict[key]['completed_outcomes']}
+                                        total_outcomes={dict[key]['total_outcomes']}
+                                        key={IDkey}
+                                        route={this.props.route}
+                                        navigation={this.props.navigation}
+                                    />
+                                )
+                            })}
+                        </SafeAreaView>
+                    </ScrollView>
+                :
+                    // If data hasn't loaded, then display loading circle
+                    <SafeAreaView style={{flex: 1, justifyContent: 'center'}}>
+                        <ActivityIndicator size="large" />
                     </SafeAreaView>
-                </ScrollView>
             ); 
-        }
-        //If data hasn't loaded, display loading circle
-        return (
-            <SafeAreaView style={{flex: 1, justifyContent: 'center'}}>
-                <ActivityIndicator size="large" />
-            </SafeAreaView>
-        );
     }
 }
 

--- a/frontend/components/pod_components/PodScreen.js
+++ b/frontend/components/pod_components/PodScreen.js
@@ -1,6 +1,6 @@
 import Constants from 'expo-constants';
 import React from 'react';
-import { SafeAreaView, ScrollView, StyleSheet } from 'react-native';
+import { ActivityIndicator, SafeAreaView, ScrollView, StyleSheet } from 'react-native';
 import { getAccessToken } from '../../utils/auth.js';
 import FocusAreaBlock from './FocusAreaBlock.js';
 
@@ -14,6 +14,7 @@ export default class PodScreen extends React.Component {
      */
     state = {
         outcomes_list: {},
+        data_loaded: false,
     };
     
     /* componentDidMount
@@ -34,6 +35,7 @@ export default class PodScreen extends React.Component {
             let data = await response.json();
             this.setState({
                 outcomes_list: data,
+                data_loaded: true,
             })
         })
         .catch(function (error) {
@@ -45,31 +47,41 @@ export default class PodScreen extends React.Component {
 	 * Paramaters: none
 	 * Returns: nothing
 	 * Purpose: renders page, which takes backend data from salesforce and 
-     * uses it to calculate progress bars 
+     * uses it to calculate progress bars. Renders a loading circle before 
+     * data has been loaded.
      * Note: map function needs a specific numbered ID key for each list item 
 	 */
     render() {
         let IDkey = 0;
+        const dict = this.state.outcomes_list;
+        //If data has loaded, then render the FocusAreaBlock
+        if (this.state.data_loaded) {
+            return (
+                <ScrollView>
+                    <SafeAreaView style={styles.container}>
+                        {Object.entries(dict).map(([key, value]) => {
+                            IDkey++;
+                            return (
+                                <FocusAreaBlock 
+                                    pod={key}
+                                    name={dict[key]['name']}
+                                    completed_outcomes={dict[key]['completed_outcomes']}
+                                    total_outcomes={dict[key]['total_outcomes']}
+                                    key={IDkey}
+                                    route={this.props.route}
+                                    navigation={this.props.navigation}
+                                />
+                            )
+                        })}
+                    </SafeAreaView>
+                </ScrollView>
+            ); 
+        }
+        //If data hasn't loaded, display loading circle
         return (
-            <ScrollView>
-                <SafeAreaView style={styles.container}>
-                    {Object.entries(this.state.outcomes_list).map(([key, value]) => {
-                        const dict = this.state.outcomes_list;
-                        IDkey++;
-                        return (
-                            <FocusAreaBlock 
-                                pod={key}
-                                name={dict[key]['name']}
-                                completed_outcomes={dict[key]['completed_outcomes']}
-                                total_outcomes={dict[key]['total_outcomes']}
-                                key={IDkey}
-                                route={this.props.route}
-                                navigation={this.props.navigation}
-                            />
-                        )
-                    })}
-                </SafeAreaView>
-            </ScrollView>
+            <SafeAreaView style={{flex: 1, justifyContent: 'center'}}>
+                <ActivityIndicator size="large" />
+            </SafeAreaView>
         );
     }
 }


### PR DESCRIPTION
Added a loading screen for OutcomesScreen.js and PodScreen.js so that when you click into it, there is a loading circle if the data hasn't loaded yet.

Steps to test PR: 
- Logging into any of the accounts, you should see a loading circle when you click into pod screen and outcomes screen right before the data has loaded.
- Note that for JumboFour (the account where the last two pods aren't assigned), the "not able to click into pod" functionality hasn't been implemented yet, so if you click associate pod or partner pod, there will just be a loading circle and no data will be called and there will be a json error in terminal

Standard Checklist:
- [ x ] Does the code work? Does it perform its intended function, the logic is correct etc.
- [ x ] Have you merged the most recent version of staging into your branch?
- [ x ] Are all merge conflicts resolved? 
- [ x ] Can any logging or debugging code be removed? (Any debugging statements should be removed)
- [ x ] Is the `diff` the **minimum amount** needed to achieve this ticket's goal? 

closes #102 