### PR TITLE
Mtw 111

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -22,6 +22,7 @@ def youthCheck(user):
 
     # Extract current pod to update from request arguments
     pod = request.args.get('pod')
+    focus_area = request.args.get('focus_area')
     pod_map_name = pod + '_POD_Map__c'
 
     # Obtain all field names for the query
@@ -44,7 +45,75 @@ def youthCheck(user):
         if name in response.keys():
             response[name]["value"] = value
 
-    return response
+    def clean_response(response):
+        new_data = []
+
+        # Helper function to find and update in new_data based on api_name
+        def find_and_update(new_data, api_name, index, field_name, get_key=False):
+            words_in_api_name = api_name.split("_")
+            curr_id = words_in_api_name[len(words_in_api_name) - 3].lower()
+            content_index = -1
+            try:
+                content_index = [ x['id'] for x in new_data[index]['content'] ].index(curr_id)
+            except ValueError:
+                content_index = -1
+            finally:
+                if content_index >= 0:
+                    if get_key:
+                        new_data[index]['content'][content_index][field_name] = api_name
+                    else:
+                        new_data[index]['content'][content_index][field_name] = response[api_name]["value"]
+                return new_data
+
+        # Extract all outcome titles for later use
+        for api_name in response.keys():
+            if "Outcome" in api_name and focus_area in api_name and "Outcomes" not in api_name:
+                new_data.append({
+                    'id': api_name[0:3],
+                    'title': response[api_name]["name"],
+                    'content': []
+                })
+        
+        # Adds task objects to content array of outcome in new_data
+        for api_name in response.keys():
+            api_name_id = api_name[0:3]
+            index = -1
+            try:
+                index = [ x['id'] for x in new_data ].index(api_name_id)
+            except ValueError:
+                index = -1
+            finally:
+                if "Youth" in api_name and index >= 0 and not "BOOL" in api_name:
+                    words_in_api_name = api_name.split("_")
+                    new_data[index]['content'].append({
+                        'api_key': api_name,
+                        'api_bool_key': "",
+                        'id': words_in_api_name[len(words_in_api_name) - 3].lower(),
+                        'key': response[api_name]["name"],
+                        'ydmApproved': True, # Change later based on salesforce data
+                        'checked': response[api_name]["value"],
+                        'starIsFilled': False, # Change later based on salesforce data
+                        'pod': pod
+                    })
+            
+        # Updates values of starIsFilled/ydmApproved in content array
+        for api_name in response.keys():
+            api_name_id = api_name[0:3]
+            index = -1
+            try:
+                index = [ x['id'] for x in new_data ].index(api_name_id)
+            except ValueError:
+                index = -1
+            finally:
+                if "YDM" in api_name and index >= 0:
+                    new_data = find_and_update(new_data, api_name, index, "ydmApproved")
+                if "BOOL" in api_name and index >= 0:
+                    new_data = find_and_update(new_data, api_name, index, "starIsFilled")
+                    new_data = find_and_update(new_data, api_name, index, "api_bool_key", get_key=True)
+
+        return { 'response': new_data}
+
+    return clean_response(response)
 
 @app.route("/updateCheckbox", methods=['POST'])
 @requires_auth(sf)

--- a/frontend/components/outcomes/Outcome.js
+++ b/frontend/components/outcomes/Outcome.js
@@ -44,17 +44,12 @@ const styles = StyleSheet.create({
 });
 
 const Outcome = (props) => {
-    // console.log(props.data);
     const [outcomeData, setOutcomeData] = useState(props.data);
     const [accessible, setAccessible] = useState(props.validPods[props.data[0].content[0].pod + "_POD_Map__c"].status === "allowed");
     
-
     function handleSetOutcomeData(backendID, updatedCheckboxValue, updatedStarValue) {
         let dataTemp = outcomeData;
-        // console.log(dataTemp);
         let index = outcomeData[0].content.findIndex(x => x.api_key === backendID);
-        // console.log(index);
-        // console.log(backendID);
         dataTemp[0].content[index].checked = updatedCheckboxValue;
         dataTemp[0].content[index].starIsFilled = updatedStarValue;
         setOutcomeData(dataTemp);

--- a/frontend/components/outcomes/Outcome.js
+++ b/frontend/components/outcomes/Outcome.js
@@ -44,16 +44,21 @@ const styles = StyleSheet.create({
 });
 
 const Outcome = (props) => {
-
+    // console.log(props.data);
     const [outcomeData, setOutcomeData] = useState(props.data);
+    const [accessible, setAccessible] = useState(props.validPods[props.data[0].content[0].pod + "_POD_Map__c"].status === "allowed");
+    
 
-    handleSetOutcomeData = (backendID, updatedCheckboxValue, updatedStarValue) => {
+    function handleSetOutcomeData(backendID, updatedCheckboxValue, updatedStarValue) {
         let dataTemp = outcomeData;
+        // console.log(dataTemp);
         let index = outcomeData[0].content.findIndex(x => x.api_key === backendID);
+        // console.log(index);
+        // console.log(backendID);
         dataTemp[0].content[index].checked = updatedCheckboxValue;
         dataTemp[0].content[index].starIsFilled = updatedStarValue;
         setOutcomeData(dataTemp);
-    };
+    }
 
     return (
         <Accordion
@@ -74,6 +79,8 @@ const Outcome = (props) => {
                         handleSetOutcomeData={handleSetOutcomeData}
                         starIsFilled={taskObj.starIsFilled}
                         pod={taskObj.pod}
+                        backendBoolID={taskObj.api_bool_key}
+                        accessible={accessible}
                     />
                 );
                 return (

--- a/frontend/components/outcomes/OutcomesScreen.js
+++ b/frontend/components/outcomes/OutcomesScreen.js
@@ -40,6 +40,7 @@ export default function OutcomesScreen({ navigation, route }) {
         });
 
         async function fetchData() {
+            // Call valid pods endpoint to gray out properly
             await fetch(`${Constants.manifest.extra.apiUrl}/getValidPods`, {
                 method: 'GET',
                 headers: {
@@ -48,104 +49,24 @@ export default function OutcomesScreen({ navigation, route }) {
             })
             .then(response => response.json())
             .then(data => {
-                // console.log(data);
                 setValidPods(data);
             })
             .catch((error) => {
                 console.error(error);
             });
+
             // Call checkbox endpoint with specific pod as argument
-            await fetch(`${Constants.manifest.extra.apiUrl}/youthCheckbox?pod=${pod}`, {
+            await fetch(`${Constants.manifest.extra.apiUrl}/youthCheckbox?pod=${pod}&focus_area=${focus_area}`, {
                 method: 'GET',
                 headers: {
                     'Authorization': "Bearer " + await getAccessToken(),
+                    'Accept': 'application/json',
+                    'Content-Type': 'application/json'
                 },
             })
                 .then(response => response.json())
                 .then(data => {
-                    let newData = [];
-
-                    function findAndUpdate(key, index, fieldName, getKey=false) {
-                        // Get ID of the current key so we can match with existing entry
-                        let words_in_key = key.split("_");
-                        let curr_id = words_in_key[words_in_key.length - 3].toLowerCase();
-                        // Finds index of object in content array to update
-                        let content_index = newData[index].content.findIndex(x => {
-                            return x.id === curr_id;
-                        });
-                        // If the corresponding youth exists for the YDM field, update the value
-                        if (content_index >= 0) {
-                            // Update ydmApproved field in existing entry
-                            if (getKey) {
-                                newData[index].content[content_index][fieldName] = key;
-                            } else {
-                                newData[index].content[content_index][fieldName] = data[key]["value"];
-                            }
-                        }
-                    }
-
-                    // Extract all outcome titles for later use
-                    for (const api_name in data) {
-                        if (api_name.includes("Outcome") && api_name.includes(focus_area) && !api_name.includes("Outcomes")) {
-                            newData.push({
-                                id: api_name.substring(0, 3),
-                                title: data[api_name]["name"],
-                                content: []
-                            });
-                        }
-                    }
-
-                    // Create all content objects based on the youth fields
-                    for (const key in data) {
-                        let key_id = key.substring(0, 3);
-                        let index = newData.findIndex(x => x.id === key_id);
-                        if (key.includes("Youth") && index >= 0 && !key.includes("BOOL")) {
-                            let words_in_key = key.split("_");
-                            newData[index].content.push({
-                                api_key: key,
-                                api_bool_key: "",
-                                id: words_in_key[words_in_key.length - 3].toLowerCase(),
-                                key: data[key]["name"],
-                                ydmApproved: true,
-                                checked: data[key]["value"],
-                                starIsFilled: false, // Change later based on salesforce data
-                                pod: pod
-                            });
-                        }
-                    }
-
-                    // Update all ydmApproved values based on YDM fields
-                    for (const key in data) {
-                        // let key_id = key.substring(0, 3);
-                        // let index = newData.findIndex(x => x.id === key_id);
-                        // if (key.includes("YDM") && index >= 0) {
-                        //     // Get ID of the current key so we can match with existing entry
-                        //     let words_in_key = key.split("_");
-                        //     let curr_id = words_in_key[words_in_key.length - 3].toLowerCase();
-                        //     // Finds index of object in content array to update
-                        //     let content_index = newData[index].content.findIndex(x => {
-                        //         return x.id === curr_id;
-                        //     });
-                        //     // If the corresponding youth exists for the YDM field, update the value
-                        //     if (content_index >= 0) {
-                        //         // Update ydmApproved field in existing entry
-                        //         newData[index].content[content_index].ydmApproved = data[key]["value"];
-                        //     }
-                        // }
-                        let key_id = key.substring(0, 3);
-                        let index = newData.findIndex(x => x.id === key_id);
-                        if (key.includes("YDM") && index >= 0) {
-                            findAndUpdate(key, index, "ydmApproved");
-                        }
-                        if (key.includes("BOOL") && index >= 0) {
-                            findAndUpdate(key, index, "starIsFilled");
-                            findAndUpdate(key, index, "api_bool_key", getKey=true);
-                        }
-                    }
-
-                    // Update the dataTemp variable with the newly parsed data
-                    setDataTemp(newData);
-                    // Update the dataLoaded variable so OutcomeScreen replaces loading circle
+                    setDataTemp(data["response"]);
                     setDataLoaded(true);
                 })
                 .catch((error) => {

--- a/frontend/components/outcomes/OutcomesScreen.js
+++ b/frontend/components/outcomes/OutcomesScreen.js
@@ -25,6 +25,7 @@ export default function OutcomesScreen({ navigation, route }) {
 
     const [dataTemp, setDataTemp] = useState([]);
     const [dataLoaded, setDataLoaded] = useState(false);
+    const [validPods, setValidPods] = useState({});
 
     useEffect(() => {
 
@@ -47,7 +48,8 @@ export default function OutcomesScreen({ navigation, route }) {
             })
             .then(response => response.json())
             .then(data => {
-                console.log(data);
+                // console.log(data);
+                setValidPods(data);
             })
             .catch((error) => {
                 console.error(error);
@@ -62,6 +64,25 @@ export default function OutcomesScreen({ navigation, route }) {
                 .then(response => response.json())
                 .then(data => {
                     let newData = [];
+
+                    function findAndUpdate(key, index, fieldName, getKey=false) {
+                        // Get ID of the current key so we can match with existing entry
+                        let words_in_key = key.split("_");
+                        let curr_id = words_in_key[words_in_key.length - 3].toLowerCase();
+                        // Finds index of object in content array to update
+                        let content_index = newData[index].content.findIndex(x => {
+                            return x.id === curr_id;
+                        });
+                        // If the corresponding youth exists for the YDM field, update the value
+                        if (content_index >= 0) {
+                            // Update ydmApproved field in existing entry
+                            if (getKey) {
+                                newData[index].content[content_index][fieldName] = key;
+                            } else {
+                                newData[index].content[content_index][fieldName] = data[key]["value"];
+                            }
+                        }
+                    }
 
                     // Extract all outcome titles for later use
                     for (const api_name in data) {
@@ -78,10 +99,11 @@ export default function OutcomesScreen({ navigation, route }) {
                     for (const key in data) {
                         let key_id = key.substring(0, 3);
                         let index = newData.findIndex(x => x.id === key_id);
-                        if (key.includes("Youth") && index >= 0) {
+                        if (key.includes("Youth") && !key.includes("BOOL") && index >= 0) {
                             let words_in_key = key.split("_");
                             newData[index].content.push({
                                 api_key: key,
+                                api_bool_key: "",
                                 id: words_in_key[words_in_key.length - 3].toLowerCase(),
                                 key: data[key]["name"],
                                 ydmApproved: true,
@@ -94,21 +116,30 @@ export default function OutcomesScreen({ navigation, route }) {
 
                     // Update all ydmApproved values based on YDM fields
                     for (const key in data) {
+                        // let key_id = key.substring(0, 3);
+                        // let index = newData.findIndex(x => x.id === key_id);
+                        // if (key.includes("YDM") && index >= 0) {
+                        //     // Get ID of the current key so we can match with existing entry
+                        //     let words_in_key = key.split("_");
+                        //     let curr_id = words_in_key[words_in_key.length - 3].toLowerCase();
+                        //     // Finds index of object in content array to update
+                        //     let content_index = newData[index].content.findIndex(x => {
+                        //         return x.id === curr_id;
+                        //     });
+                        //     // If the corresponding youth exists for the YDM field, update the value
+                        //     if (content_index >= 0) {
+                        //         // Update ydmApproved field in existing entry
+                        //         newData[index].content[content_index].ydmApproved = data[key]["value"];
+                        //     }
+                        // }
                         let key_id = key.substring(0, 3);
                         let index = newData.findIndex(x => x.id === key_id);
                         if (key.includes("YDM") && index >= 0) {
-                            // Get ID of the current key so we can match with existing entry
-                            let words_in_key = key.split("_");
-                            let curr_id = words_in_key[words_in_key.length - 3].toLowerCase();
-                            // Finds index of object in content array to update
-                            let content_index = newData[index].content.findIndex(x => {
-                                return x.id === curr_id;
-                            });
-                            // If the corresponding youth exists for the YDM field, update the value
-                            if (content_index >= 0) {
-                                // Update ydmApproved field in existing entry
-                                newData[index].content[content_index].ydmApproved = data[key]["value"];
-                            }
+                            findAndUpdate(key, index, "ydmApproved");
+                        }
+                        if (key.includes("BOOL") && index >= 0) {
+                            findAndUpdate(key, index, "starIsFilled");
+                            findAndUpdate(key, index, "api_bool_key", getKey=true);
                         }
                     }
 
@@ -136,7 +167,10 @@ export default function OutcomesScreen({ navigation, route }) {
                         data={dataTemp}
                         renderItem={({ item }) => {
                             return (
-                                <Outcome data={[item]}/>
+                                <Outcome 
+                                    data={[item]}
+                                    validPods={validPods}
+                                />
                             );
                         }}
                         keyExtractor={item => item.title}

--- a/frontend/components/outcomes/Task.js
+++ b/frontend/components/outcomes/Task.js
@@ -71,28 +71,8 @@ class Task extends React.Component {
     }
 
     async updateSalesforce(updated_value, isStar) {
-        // let updated_value = !this.state.checked
-
-        // // Make request to update checkbox
-        // await fetch(`${Constants.manifest.extra.apiUrl}/updateCheckbox`, {
-        //     method: 'POST',
-        //     headers: {
-        //         'Authorization': "Bearer " + await getAccessToken(),
-        //         'Accept': 'application/json',
-        //         'Content-Type': 'application/json'
-        //     },
-        //     body: JSON.stringify({
-        //         task_title: this.props.backendID,
-        //         new_value: updated_value,
-        //         pod: this.props.pod
-        //     })
-        // })
-        // .catch(error => {
-        //     console.error(error);
-        // });
         success = false;
         // Make request to update checkbox
-        // KNOWN ISSUE: 401 error occurring for several (but not all) tasks in the Associate pod.
         await fetch(`${Constants.manifest.extra.apiUrl}/updateCheckbox`, {
             method: 'POST',
             headers: {
@@ -107,7 +87,6 @@ class Task extends React.Component {
             })
         })
         .then(response => {
-            // console.log("status code:", response.status);
             if (response.status != 200) {
                 success = false;
             } else {
@@ -121,28 +100,8 @@ class Task extends React.Component {
         return success;
     }
 
-    // updateStatus() {
-    //     if (this.props.validPods[this.props.pod + '_POD_Map__c'].status === "no access") {
-    //         // this.setState({taskColor: "#C4C4C4"});
-    //         // this.setState({starColor: "#C4C4C4"});
-    //         this.setState({clickable: false});
-    //         return "#C4C4C4";
-    //     } else if (this.state.ydmApproved) {
-    //         // this.setState({taskColor: "#C4C4C4"});
-    //         // this.setState({starColor: "#C4C4C4"});
-    //         this.setState({clickable: false});
-    //         return "#C4C4C4";
-    //     } else {
-    //         // this.setState({taskColor: "#3F3F3F"});
-    //         // this.setState({starColor: "#FF4646"});
-    //         this.setState({clickable: true});
-    //         return "#3F3F3F";
-    //     }
-    // }
-
     render() {
         let name = this.props.name;
-        // this.updateStatus();
 
         return (
             <View style={this.styles().taskContainer}>
@@ -159,15 +118,13 @@ class Task extends React.Component {
                         let success = this.updateSalesforce(!this.state.starIsFilled, true);
                         if (success) {
                             this.props.handleSetOutcomeData(this.props.backendID, this.state.checked, !this.state.starIsFilled);
-                            // this.setState({starIsFilled: !this.state.starIsFilled});
+                            // Prevent user from clicking again until a second has passed
                             this.setState({starIsFilled: !this.state.starIsFilled}, () => {
                                 setTimeout(() => { this.setClickable(true); }, 1000);
                             });
                         } else {
                             this.setClickable(true);
                         }
-                        // Add functionality for keeping the state (local or Salesforce)
-                        // If the star is now filled, add the current task to the "Favorites" section
                     }}
                 />
 

--- a/frontend/components/outcomes/Task.js
+++ b/frontend/components/outcomes/Task.js
@@ -25,7 +25,8 @@ class Task extends React.Component {
             checked: props.checked,
             ydmApproved: props.ydmApproved,
             starIsFilled: props.ydmApproved ? false : props.starIsFilled, // change second value later based on local storage
-            clickable: true
+            clickable: true,
+            taskColor: props.ydmApproved ? "#C4C4C4" : "#3F3F3F"
         };
     }
 
@@ -52,11 +53,16 @@ class Task extends React.Component {
             text: {
                 flex: 1,
                 textAlign: 'left',
-                color: this.state.ydmApproved ? "#C4C4C4" : "#3F3F3F",
+                color: this.state.ydmApproved || !this.props.accessible ? "#C4C4C4" : "#3F3F3F",
             },
             checkboxContainer: {
                 paddingRight: 0,
-            }
+            },
+            greyText: {
+                flex: 1,
+                textAlign: 'left',
+                color: '#C4C4C4',
+            },
         });
     }
 
@@ -64,10 +70,29 @@ class Task extends React.Component {
         this.setState({clickable: newValue});
     }
 
-    async updateSalesforce() {
-        let updated_value = !this.state.checked
+    async updateSalesforce(updated_value, isStar) {
+        // let updated_value = !this.state.checked
 
+        // // Make request to update checkbox
+        // await fetch(`${Constants.manifest.extra.apiUrl}/updateCheckbox`, {
+        //     method: 'POST',
+        //     headers: {
+        //         'Authorization': "Bearer " + await getAccessToken(),
+        //         'Accept': 'application/json',
+        //         'Content-Type': 'application/json'
+        //     },
+        //     body: JSON.stringify({
+        //         task_title: this.props.backendID,
+        //         new_value: updated_value,
+        //         pod: this.props.pod
+        //     })
+        // })
+        // .catch(error => {
+        //     console.error(error);
+        // });
+        success = false;
         // Make request to update checkbox
+        // KNOWN ISSUE: 401 error occurring for several (but not all) tasks in the Associate pod.
         await fetch(`${Constants.manifest.extra.apiUrl}/updateCheckbox`, {
             method: 'POST',
             headers: {
@@ -76,18 +101,48 @@ class Task extends React.Component {
                 'Content-Type': 'application/json'
             },
             body: JSON.stringify({
-                task_title: this.props.backendID,
+                task_title: isStar ? this.props.backendBoolID : this.props.backendID,
                 new_value: updated_value,
                 pod: this.props.pod
             })
         })
+        .then(response => {
+            // console.log("status code:", response.status);
+            if (response.status != 200) {
+                success = false;
+            } else {
+                success = true;
+            }
+        })
         .catch(error => {
             console.error(error);
+            success = false;
         });
+        return success;
     }
+
+    // updateStatus() {
+    //     if (this.props.validPods[this.props.pod + '_POD_Map__c'].status === "no access") {
+    //         // this.setState({taskColor: "#C4C4C4"});
+    //         // this.setState({starColor: "#C4C4C4"});
+    //         this.setState({clickable: false});
+    //         return "#C4C4C4";
+    //     } else if (this.state.ydmApproved) {
+    //         // this.setState({taskColor: "#C4C4C4"});
+    //         // this.setState({starColor: "#C4C4C4"});
+    //         this.setState({clickable: false});
+    //         return "#C4C4C4";
+    //     } else {
+    //         // this.setState({taskColor: "#3F3F3F"});
+    //         // this.setState({starColor: "#FF4646"});
+    //         this.setState({clickable: true});
+    //         return "#3F3F3F";
+    //     }
+    // }
 
     render() {
         let name = this.props.name;
+        // this.updateStatus();
 
         return (
             <View style={this.styles().taskContainer}>
@@ -95,13 +150,22 @@ class Task extends React.Component {
                     style={this.styles().starContainer}
                     name={this.state.starIsFilled ? "star" : "star-border"}
                     iconStyle={this.styles().star}
-                    color={this.state.ydmApproved ? "#C4C4C4" : "#FF4646"}
+                    color={!this.props.accessible || this.state.ydmApproved ? "#C4C4C4" : "#FF4646"}
                     backgroundColor='transparent'
                     underlayColor='transparent'
                     size={20}
-                    onPress={this.state.ydmApproved ? null : () => {
-                        this.props.handleSetOutcomeData(this.props.backendID, this.state.checked, !this.state.starIsFilled);
-                        this.setState({starIsFilled: !this.state.starIsFilled});
+                    onPress={!this.props.accessible || this.state.ydmApproved || !this.state.clickable ? null : () => {
+                        this.setClickable(false);
+                        let success = this.updateSalesforce(!this.state.starIsFilled, true);
+                        if (success) {
+                            this.props.handleSetOutcomeData(this.props.backendID, this.state.checked, !this.state.starIsFilled);
+                            // this.setState({starIsFilled: !this.state.starIsFilled});
+                            this.setState({starIsFilled: !this.state.starIsFilled}, () => {
+                                setTimeout(() => { this.setClickable(true); }, 1000);
+                            });
+                        } else {
+                            this.setClickable(true);
+                        }
                         // Add functionality for keeping the state (local or Salesforce)
                         // If the star is now filled, add the current task to the "Favorites" section
                     }}
@@ -116,18 +180,21 @@ class Task extends React.Component {
                     name={this.state.checked ? 'check-box' : 
                           'check-box-outline-blank'}
                     iconStyle={this.styles().checkbox}
-                    color={this.state.ydmApproved ? "#C4C4C4" : "#3F3F3F"}
+                    color={!this.props.accessible || this.state.ydmApproved ? "#C4C4C4" : "#3F3F3F"}
                     backgroundColor='transparent'
                     underlayColor='transparent'
-                    // KNOWN ISSUE: 401 error from multiple requests made in a short amount of time
-                    onPress={this.state.ydmApproved || !this.state.clickable ? null : () => {
+                    onPress={!this.props.accessible || this.state.ydmApproved || !this.state.clickable ? null : () => {
                         this.setClickable(false);
-                        this.updateSalesforce();
-                        this.props.handleSetOutcomeData(this.props.backendID, !this.state.checked, this.state.starIsFilled);
-                        // Prevent user from clicking again until a second has passed
-                        this.setState({checked: !this.state.checked}, () => {
-                            setTimeout(() => { this.setClickable(true); }, 1000);
-                        });
+                        let success = this.updateSalesforce(!this.state.checked, false);
+                        if (success) {
+                            this.props.handleSetOutcomeData(this.props.backendID, !this.state.checked, this.state.starIsFilled);
+                            // Prevent user from clicking again until a second has passed
+                            this.setState({checked: !this.state.checked}, () => {
+                                setTimeout(() => { this.setClickable(true); }, 1000);
+                            });
+                        } else {
+                            this.setClickable(true);
+                        }
                     }}
                 />
             </View>


### PR DESCRIPTION
This PR includes a fix for a bug which occurred when clicking the checkbox of the last Task of an Outcome. This fix should still be verified on iOS/iPadOS before this PR is approved to merge into staging.

Another fix includes the persistence of the star state in Salesforce - previously, this had been implemented on another branch, but not in staging or mtw-111. Clicking a star icon should now update the corresponding Main Goal field on Salesforce.

Furthermore, the frontend data formatting for tasks/outcomes has been moved to the backend. The behavior of the backend endpoint exactly matches the format previously obtained via frontend logic.

Lastly, pods that are not currently available to the user should be properly greyed out through use of Alec's getValidPods endpoint. Currently, the call to this endpoint occurs in OutcomesScreen.js, but in the future, it could potentially be abstracted to a higher component (App.js or HomeScreenPod.js, potentially), then the relevant data could be passed down to child components where necessary.

Please let Alec or myself know if you have any questions!

Steps to test PR: Manually verify by running the app through Expo.

Standard Checklist:
- [X] Does the code work? Does it perform its intended function, the logic is correct etc.
- [X] Have you merged the most recent version of staging into your branch?
- [X] Are all merge conflicts resolved? 
- [X] Can any logging or debugging code be removed? (Any debugging statements should be removed)
- [X] Is the `diff` the **minimum amount** needed to achieve this ticket's goal? 
