### PR TITLE
mtw-110 Un-clickable for pods that "do not exist" on HomeScreen

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -264,7 +264,6 @@ def findValid(user):
         sf_result = sf.query(format_soql((soql + " WHERE (Contact__r.auth0_user_id__c={user_id})"), user_id=user_id))
         
         if len(sf_result["records"]) == 0:
-            print('this is empty: ', pod_map_name)
             total_dict[pod_map_name] = {'status': 'does not exist', 'completed': False}
             continue
         

--- a/backend/app.py
+++ b/backend/app.py
@@ -175,22 +175,27 @@ def HomeScreenoutcomes(user):
     soql = query_from.format(','.join(Pod_field_names))
     Pod_sf_result = sf.query(format_soql((soql + " WHERE Contact__r.auth0_user_id__c={user_id}"), user_id=user_id))
 
-    # calculate Trainee total 
-    Pod_total_count = 0; #create new value in sf_result dict that will store field's total outcomes 
-    for field in Pod_field_names:
-        field_type = field[3:6].upper()
-        for name_and_label in field_names_and_labels:
-            if "_Outcome_" + field_type in name_and_label[0]: 
-                Pod_total_count += 1
+    if len(Pod_sf_result["records"]) == 0:
+        Pod_outcome_sum = 0
+        Pod_total_count = 0
     
+    else:
+        # calculate Trainee total 
+        Pod_total_count = 0; #create new value in sf_result dict that will store field's total outcomes 
+        for field in Pod_field_names:
+            field_type = field[3:6].upper()
+            for name_and_label in field_names_and_labels:
+                if "_Outcome_" + field_type in name_and_label[0]: 
+                    Pod_total_count += 1
+        
 
-    # transform into a python dictionary
-    vars(Pod_sf_result)
+        # transform into a python dictionary
+        vars(Pod_sf_result)
 
-    # calculate *Trainee* outcomes based on all related fields
-    Pod_outcome_sum = 0
-    for outcome in Pod_field_names:
-        Pod_outcome_sum += Pod_sf_result['records'][0][outcome]
+        # calculate *Trainee* outcomes based on all related fields
+        Pod_outcome_sum = 0
+        for outcome in Pod_field_names:
+            Pod_outcome_sum += Pod_sf_result['records'][0][outcome]
 
     pod_outcome = {
         'progress': Pod_outcome_sum,
@@ -257,7 +262,9 @@ def findValid(user):
         # Query for all fields for this user
         soql = ("SELECT {} FROM " + pod_map_name).format(','.join(field_names))
         sf_result = sf.query(format_soql((soql + " WHERE (Contact__r.auth0_user_id__c={user_id})"), user_id=user_id))
+        
         if len(sf_result["records"]) == 0:
+            print('this is empty: ', pod_map_name)
             total_dict[pod_map_name] = {'status': 'does not exist', 'completed': False}
             continue
         

--- a/frontend/components/pod_components/FocusAreaBlock.js
+++ b/frontend/components/pod_components/FocusAreaBlock.js
@@ -21,7 +21,6 @@ export default class FocusAreaBlock extends React.Component {
         const total_outcomes = this.props.total_outcomes;
         const pod_name = this.props.name;
         const pod_status = this.props.route.params.status;
-        console.log(pod_status);
         return (     
             <TouchableOpacity 
                 style={styles.block} 

--- a/frontend/components/pod_components/HomeScreenPod.js
+++ b/frontend/components/pod_components/HomeScreenPod.js
@@ -7,7 +7,7 @@ import { getAccessToken } from '../../utils/auth.js';
 import ProgressBar from '../ProgressBar.js';
 
 const server_add = Constants.manifest.extra.apiUrl;
-
+const error_message = "This pod is not clickable because it hasn't been generated yet. If you think this is a mistake, please contact your More Than Words manager. "
 
 export default class HomeScreenPod extends React.Component{
     state = {
@@ -16,7 +16,6 @@ export default class HomeScreenPod extends React.Component{
         status: "",
         completed: ""
     };
-    
 
     async fetchData() {
         try{
@@ -50,7 +49,6 @@ export default class HomeScreenPod extends React.Component{
             console.error(e);
         }
     };  
-    
 
     componentDidMount(){
         this.fetchData();
@@ -61,6 +59,9 @@ export default class HomeScreenPod extends React.Component{
         const nav_pod_name = pod_name + ' Pod';
         const complete_outcomes = this.state.progress;       
         const total_outcomes = this.state.total;
+        const pod_status = this.state.status;
+        const pod_completed = this.state.completed;
+
         let blocktext,block;
         if (complete_outcomes != 0 && complete_outcomes == total_outcomes){
             blocktext = styles.BlockText;
@@ -72,18 +73,21 @@ export default class HomeScreenPod extends React.Component{
             blocktext = styles.greyBlockText;
             block = styles.greyBlock;
         } 
-            
+
+
         return(
         <SafeAreaView style={styles.container}>
         <TouchableOpacity 
             style={block} 
-                onPress={() => 
+            onPress={() => {
+                if (pod_status == 'does not exist'){
+                    alert(error_message);
+                } else{
                     this.props.navigation.navigate(nav_pod_name, {
-                    pod: pod_name,
-                    status: this.state.status,
-                    completed: this.state.completed,
-                })
-            }
+                        pod: pod_name,
+                        status: this.state.status,
+                        completed: this.state.completed,
+                    })}}}
         >
                 <Text style={blocktext}> {pod_name} </Text>
             <ProgressBar progress={complete_outcomes} total_outcomes={total_outcomes} />


### PR DESCRIPTION
**Status Spec(on HomeScreen):**
- allowed : still clickable
- no access : still clickable (but users shouldn't be on)
- does not exist: 🚫 not clickable

___________________________________________________
**Changes:**

  app.py
  - add extra statement to check if pods exist
  
  HomeScreen.js
  - Make pods without any data non-clickable
  - Add alert statement for pods that do not exist

___________________________________________________
**Steps to test the PR:**
1. log in through Jumbo 1, all pods should be clickable even though Associate and Partner are of status "no access"

> titapa.punpun@gmail.com 
> JumboOne!!

2. log in through Jumbo 4, when clicking Associate & Partner pods, an alert statement would show up. 

> titapa.chaiyakiturajai@tufts.edu
> JumboFour!!

___________________________________________________
Standard Checklist:
- [X] Does the code work? Does it perform its intended function, the logic is correct etc.
- [X] Have you merged the most recent version of staging into your branch?
- [X] Are all merge conflicts resolved? 
- [X] Can any logging or debugging code be removed? (Any debugging statements should be removed)
- [X] Is the `diff` the **minimum amount** needed to achieve this ticket's goal? 
